### PR TITLE
Bump version from 0.1.3 to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eplace"
-version = "0.1.3"
+version = "0.1.4"
 description = "ePLACE: environmental Phylogenetic Localisation and Clade Estimation - A library for analyzing eDNA sequences"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/eplace_lib/__init__.py
+++ b/src/eplace_lib/__init__.py
@@ -5,7 +5,13 @@ ePLACE (environmental Phylogenetic Localisation and Clade Estimation)
 provides tools for analyzing environmental DNA sequences.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("eplace")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 __author__ = "Rob Edwards"
 
 # Import main classes for convenient access


### PR DESCRIPTION
Prepares a new ePLACE library release by bumping the package version and ensuring consistency between packaging metadata and the in-code version constant.

## Changes Made

- **Version bump**: Updated `pyproject.toml` version from `0.1.3` to `0.1.4`.
- **Single source of truth**: Replaced the hardcoded `__version__ = "0.1.0"` in `src/eplace_lib/__init__.py` with a dynamic lookup using `importlib.metadata.version("eplace")`, so the version is always derived from the installed package metadata. A `PackageNotFoundError` fallback to `"unknown"` is included for environments where the package is not installed.