### PR TITLE
Nbdl header support

### DIFF
--- a/src/eplace_lib/blast_analysis.py
+++ b/src/eplace_lib/blast_analysis.py
@@ -9,7 +9,7 @@ import os
 import re
 import subprocess
 import logging
-from typing import Optional, Dict, Tuple
+from typing import Optional, Dict, Tuple, Callable
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -136,7 +136,38 @@ def _extract_accession_from_pipe_id(seq_id: str) -> str:
     return seq_id
 
 
-def normalize_sequence_id(seq_id: str) -> str:
+def _parse_nbdl_custom_header(header: str) -> str:
+    """
+    Parse a custom NBDL database header to extract the sequence ID.
+    
+    This parser handles headers in the NBDL format:
+    >NBDL-HR5SFP7MHKSYMG.v1.mt|13904-15593|+|MT-RNR2 [species=...] [dbxref=...] ...
+    
+    The sequence ID is extracted as the first pipe-delimited segment before
+    any square bracket metadata.
+    
+    Args:
+        header: The full FASTA header (including '>').
+    
+    Returns:
+        The extracted sequence ID (typically everything before the first space or bracket).
+    """
+    if not header:
+        return header
+    
+    # Remove leading '>'
+    header = header.lstrip('>')
+    
+    # Take the first token (before whitespace or bracket)
+    # Most NBDL headers have the sequence ID as the first component
+    match = re.match(r'([^\s\[]+)', header)
+    if match:
+        return match.group(1)
+    
+    return header
+
+
+def normalize_sequence_id(seq_id: str, parser: Optional[Callable[[str], str]] = None) -> str:
     """
     Normalize an arbitrary sequence or tree label to a canonical accession-like identifier.
 
@@ -150,15 +181,22 @@ def normalize_sequence_id(seq_id: str) -> str:
     4. If the token contains pipes ('|'), extract the accession via _extract_accession_from_pipe_id()
        (gi|...|gb|ACC|, ref|ACC|, gb|ACC|, etc.).
     5. Otherwise return the token unchanged.
+    
+    If a custom parser is provided, it will be used instead of the default NCBI-style parsing.
 
     Args:
         seq_id: Raw sequence identifier from any source.
+        parser: Optional custom parser function to apply instead of default parsing.
 
     Returns:
         Canonical accession string suitable for exact comparison.
     """
     if not seq_id:
         return seq_id
+
+    # If a custom parser is provided, use it
+    if parser:
+        return parser(seq_id)
 
     # Step 1: strip leading '>'
     token = seq_id.lstrip('>')

--- a/src/eplace_lib/blast_analysis.py
+++ b/src/eplace_lib/blast_analysis.py
@@ -136,35 +136,46 @@ def _extract_accession_from_pipe_id(seq_id: str) -> str:
     return seq_id
 
 
-def _parse_nbdl_custom_header(header: str) -> str:
+def _parse_nbdl_custom_header(header: str) -> Tuple[str, str, str]:
     """
-    Parse a custom NBDL database header to extract the sequence ID.
+    Parse a custom NBDL database header to extract key components.
     
     This parser handles headers in the NBDL format:
-    >NBDL-HR5SFP7MHKSYMG.v1.mt|13904-15593|+|MT-RNR2 [species=...] [dbxref=...] ...
+    >NBDL-HR5SFP7MHKSYMG.v1.mt|13904-15593|+|MT-RNR2 [species=...] [dbxref=...] ... |taxid=80951
     
-    The sequence ID is extracted as the first pipe-delimited segment before
-    any square bracket metadata.
+    Extracts:
+    1. Sequence ID: Everything before the first space/bracket (e.g., NBDL-HR5SFP7MHKSYMG.v1.mt|13904-15593|+|MT-RNR2)
+    2. Description: The description text between the end of sequence ID and first bracket (e.g., organism name and gene description)
+    3. TaxID: The taxid value from the final |taxid=XXXXX segment
     
     Args:
         header: The full FASTA header (including '>').
     
     Returns:
-        The extracted sequence ID (typically everything before the first space or bracket).
+        Tuple of (sequence_id, description, taxid) or (sequence_id, '', '') if parsing fails.
     """
     if not header:
-        return header
+        return (header, '', '')
     
     # Remove leading '>'
     header = header.lstrip('>')
     
-    # Take the first token (before whitespace or bracket)
-    # Most NBDL headers have the sequence ID as the first component
-    match = re.match(r'([^\s\[]+)', header)
-    if match:
-        return match.group(1)
+    # Extract sequence ID (first token before space or bracket)
+    seq_id_match = re.match(r'([^\s\[]+)', header)
+    seq_id = seq_id_match.group(1) if seq_id_match else header
     
-    return header
+    # Extract taxid from the header (look for |taxid=XXXXX pattern)
+    taxid = ''
+    taxid_match = re.search(r'\|taxid=(\d+)', header)
+    if taxid_match:
+        taxid = taxid_match.group(1)
+    
+    # Extract description: the text between sequence ID and first bracket
+    # This captures organism name and gene description
+    desc_match = re.search(r'^' + re.escape(seq_id) + r'\s+([^\[]*)', header)
+    description = desc_match.group(1).strip() if desc_match else ''
+    
+    return (seq_id, description, taxid)
 
 
 def normalize_sequence_id(seq_id: str, parser: Optional[Callable[[str], str]] = None) -> str:

--- a/src/eplace_lib/nbdl_cli.py
+++ b/src/eplace_lib/nbdl_cli.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python
+"""
+NBDL-aware ePLACE command line wrapper.
+
+This module adds a small command that can search BLAST databases built from
+CSIRO/NBDL-style FASTA headers such as::
+
+    >NBDL-...|MT-RNR2 [organism=Dascyllus reticulatus] ... |taxid=80951
+
+The normal ePLACE BLAST workflow asks BLAST for staxid/staxids. Custom BLAST
+DBs may not return those fields unless the database was built with a taxid map.
+Here we additionally request the subject title (stitle) and, when BLAST does not
+provide a usable taxid, parse ``|taxid=...`` from the FASTA header.
+"""
+
+import argparse
+import logging
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .alignment import (
+    IQTreeBuilder,
+    check_alignment_consistency,
+    create_grouped_fasta_with_queries,
+    group_hits_by_group_rank,
+    process_grouped_alignment_and_tree_parallel,
+    process_query_alignment_and_tree_parallel,
+)
+from .blast_analysis import BlastHit, BlastRunner, FastaReader, _parse_nbdl_custom_header
+from .taxonomy import (
+    VALID_RANKS,
+    generate_classification_summary,
+    process_blast_results_for_taxonomy,
+    rewrite_blast_hits,
+)
+
+logger = logging.getLogger(__name__)
+
+RANK_CHOICES = [rank for rank in VALID_RANKS if rank != "domain"]
+SEARCH_OUTFMT_WITH_TITLE = (
+    "6 qseqid sseqid pident length qlen slen qstart qend "
+    "sstart send evalue bitscore staxid staxids stitle"
+)
+
+
+def _safe_id(value: str) -> str:
+    return value.replace("|", "_").replace("/", "_").replace(" ", "_")
+
+
+def _is_missing_taxid(value: Optional[str]) -> bool:
+    return value is None or value.strip() in {"", "0", "N/A", "NA", "-"}
+
+
+def _parse_blast_results_with_nbdl_titles(blast_output: Path) -> List[BlastHit]:
+    """Parse BLAST tabular output and recover taxids from NBDL subject titles.
+
+    The expected output format is ``SEARCH_OUTFMT_WITH_TITLE``. Older BLAST
+    result files without ``stitle`` are still accepted, but no NBDL fallback is
+    possible for those lines.
+    """
+    if not blast_output.exists():
+        raise FileNotFoundError(f"BLAST output file not found: {blast_output}")
+
+    hits: List[BlastHit] = []
+    with open(blast_output, "r") as handle:
+        for line_num, line in enumerate(handle, 1):
+            line = line.rstrip("\n")
+            if not line or line.startswith("#"):
+                continue
+
+            fields = line.split("\t")
+            if len(fields) < 12:
+                raise ValueError(
+                    f"Invalid BLAST output format at line {line_num}: "
+                    f"expected at least 12 fields, got {len(fields)}"
+                )
+
+            query_id = fields[0]
+            subject_id = fields[1]
+            percent_identity = float(fields[2])
+            alignment_length = int(fields[3])
+            query_length = int(fields[4])
+            subject_length = int(fields[5])
+            query_start = int(fields[6])
+            query_end = int(fields[7])
+            subject_start = int(fields[8])
+            subject_end = int(fields[9])
+            evalue = float(fields[10])
+            bit_score = float(fields[11])
+            staxid = fields[12] if len(fields) > 12 else ""
+            staxids = fields[13] if len(fields) > 13 else ""
+            subject_title = fields[14] if len(fields) > 14 else ""
+
+            if _is_missing_taxid(staxid) and subject_title:
+                parsed_subject_id, _description, parsed_taxid = _parse_nbdl_custom_header(subject_title)
+                if parsed_taxid:
+                    staxid = parsed_taxid
+                    staxids = parsed_taxid if _is_missing_taxid(staxids) else staxids
+                    if subject_id in {"", "N/A", "NA"}:
+                        subject_id = parsed_subject_id
+                    logger.debug(
+                        "Recovered taxid %s for subject %s from NBDL header",
+                        parsed_taxid,
+                        subject_id,
+                    )
+
+            query_coverage = (abs(query_end - query_start) + 1) / query_length * 100
+            hits.append(
+                BlastHit(
+                    query_id=query_id,
+                    subject_id=subject_id,
+                    percent_identity=percent_identity,
+                    alignment_length=alignment_length,
+                    query_length=query_length,
+                    subject_length=subject_length,
+                    query_start=query_start,
+                    query_end=query_end,
+                    subject_start=subject_start,
+                    subject_end=subject_end,
+                    evalue=evalue,
+                    bit_score=bit_score,
+                    query_coverage=query_coverage,
+                    subject_taxid=staxid,
+                    subject_taxids=staxids,
+                )
+            )
+
+    return hits
+
+
+def run_nbdl_blast_search(
+    query_fasta: Path,
+    output_file: Path,
+    min_identity: float,
+    min_coverage: float,
+    database: str,
+    blastdb_path: Optional[Path],
+    num_threads: int,
+    skip_existing: bool,
+) -> Tuple[bool, List[BlastHit]]:
+    """Run BLAST using ``stitle`` so NBDL taxids can be parsed from headers."""
+    runner = BlastRunner(blastdb_path)
+
+    if output_file.exists() and skip_existing:
+        logger.info("Using existing BLAST output: %s", output_file)
+    else:
+        success = runner.run_blastn(
+            query_fasta=query_fasta,
+            output_file=output_file,
+            database=database,
+            num_threads=num_threads,
+            outfmt=SEARCH_OUTFMT_WITH_TITLE,
+        )
+        if not success:
+            return False, []
+
+    try:
+        hits = _parse_blast_results_with_nbdl_titles(output_file)
+        filtered_hits = runner.filter_blast_hits(
+            hits,
+            min_identity=min_identity,
+            min_coverage=min_coverage,
+        )
+        return True, filtered_hits
+    except Exception as exc:
+        logger.error("Error processing NBDL-aware BLAST results: %s", exc)
+        return False, []
+
+
+def _process_taxonomy_and_representatives(args, filtered_hits: List[BlastHit]) -> Dict[str, Optional[Path]]:
+    return process_blast_results_for_taxonomy(
+        blast_hits=filtered_hits,
+        output_dir=args.output_dir,
+        rank=args.rank,
+        database=args.database,
+        blastdb_path=args.blastdb_path,
+    )
+
+
+def search_command(args) -> int:
+    if not args.query_fasta.exists():
+        logger.error("Query FASTA file not found: %s", args.query_fasta)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    sequences = FastaReader.read_fasta(args.query_fasta)
+    search_output = args.output_dir / "blast_results.txt"
+
+    success, filtered_hits = run_nbdl_blast_search(
+        query_fasta=args.query_fasta,
+        output_file=search_output,
+        min_identity=args.min_identity,
+        min_coverage=args.min_coverage,
+        database=args.database,
+        blastdb_path=args.blastdb_path,
+        num_threads=args.num_threads,
+        skip_existing=not args.overwrite_existing_blast,
+    )
+    if not success:
+        return 1
+
+    _process_taxonomy_and_representatives(args, filtered_hits)
+    rewrite_blast_hits(filtered_hits, args.output_dir / "blast_results_annotated.txt", header=True)
+
+    tree_files_map = {}
+    if not args.skip_alignment:
+        hits_by_query = defaultdict(list)
+        for hit in filtered_hits:
+            hits_by_query[hit.query_id].append(hit)
+
+        tree_jobs = []
+        query_job_info = {}
+        for query_id, query_hits in hits_by_query.items():
+            query_dir = args.output_dir / _safe_id(query_id)
+            result = process_query_alignment_and_tree_parallel(
+                query_id=query_id,
+                query_dir=query_dir,
+                blast_hits=query_hits,
+                taxonomic_rank=args.tree_label_rank,
+                query_fasta=args.query_fasta,
+                num_threads=args.num_threads,
+                background_tree=True,
+            )
+            if result["tree_job"]:
+                tree_jobs.append(result["tree_job"])
+                query_job_info[str(result["tree_file"])] = {
+                    "query_id": query_id,
+                    "tree_file": result["tree_file"],
+                    "labeled_tree_path": result["labeled_tree_path"],
+                    "blast_hits": result["blast_hits"],
+                    "taxonomic_rank": result["taxonomic_rank"],
+                }
+
+        if tree_jobs:
+            tree_results = IQTreeBuilder.wait_for_tree_jobs(tree_jobs)
+            for tree_path, tree_success in tree_results.items():
+                if not tree_success or tree_path not in query_job_info:
+                    continue
+                job_info = query_job_info[tree_path]
+                tree_files_map[job_info["query_id"]] = job_info["tree_file"]
+                if args.tree_label_rank == "no_rank":
+                    logger.info("Skipping tree relabeling in no_rank mode for %s", job_info["query_id"])
+                    continue
+                IQTreeBuilder.relabel_tree_with_taxonomy(
+                    tree_file=job_info["tree_file"],
+                    blast_hits=job_info["blast_hits"],
+                    output_tree=job_info["labeled_tree_path"],
+                    taxonomic_rank=job_info["taxonomic_rank"],
+                )
+
+    output_classification = args.output_classification or args.output_dir / f"{args.query_fasta.stem}_classification.tsv"
+    generate_classification_summary(
+        sequences=sequences,
+        blast_hits=filtered_hits,
+        output_file=output_classification,
+        rank=args.rank,
+        group_rank=args.rank,
+        tree_label_rank=args.tree_label_rank,
+        tree_files=tree_files_map or None,
+    )
+    logger.info("NBDL-aware search workflow completed")
+    return 0
+
+
+def _group_hits_for_nbdl(filtered_hits: List[BlastHit], group_rank: str):
+    if group_rank == "no_rank":
+        grouped = defaultdict(lambda: defaultdict(list))
+        for hit in filtered_hits:
+            grouped["no_rank"][hit.query_id].append(hit)
+        return dict(grouped)
+    return group_hits_by_group_rank(filtered_hits, group_rank)
+
+
+def grouped_command(args) -> int:
+    if not args.query_fasta.exists():
+        logger.error("Query FASTA file not found: %s", args.query_fasta)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    sequences = FastaReader.read_fasta(args.query_fasta)
+    search_output = args.output_dir / "blast_results.txt"
+
+    success, filtered_hits = run_nbdl_blast_search(
+        query_fasta=args.query_fasta,
+        output_file=search_output,
+        min_identity=args.min_identity,
+        min_coverage=args.min_coverage,
+        database=args.database,
+        blastdb_path=args.blastdb_path,
+        num_threads=args.num_threads,
+        skip_existing=not args.overwrite_existing_blast,
+    )
+    if not success:
+        return 1
+
+    _process_taxonomy_and_representatives(args, filtered_hits)
+    rewrite_blast_hits(filtered_hits, args.output_dir / "blast_results_annotated.txt", header=True)
+
+    consistency = check_alignment_consistency(filtered_hits, tolerance=args.alignment_tolerance)
+    inconsistent = sum(1 for status in consistency.values() if not status)
+    if inconsistent:
+        logger.warning("Found %s reference sequences with inconsistent alignments", inconsistent)
+
+    grouped_hits = _group_hits_for_nbdl(filtered_hits, args.group_rank)
+    if not grouped_hits:
+        logger.error("No groups found after grouping by %s", args.group_rank)
+        return 1
+
+    group_results = {}
+    for group_id, query_hits_map in grouped_hits.items():
+        group_name = group_id
+        group_dir = args.output_dir / _safe_id(group_name)
+        group_dir.mkdir(parents=True, exist_ok=True)
+        combined_fasta = group_dir / f"{_safe_id(group_name)}_combined.fasta"
+
+        success = create_grouped_fasta_with_queries(
+            group_tid=group_id,
+            group_name=group_name,
+            query_hits_map=query_hits_map,
+            labeling_rank=args.rank,
+            query_fasta=args.query_fasta,
+            output_fasta=combined_fasta,
+            database=args.database,
+            blastdb_path=args.blastdb_path,
+        )
+        if success:
+            group_results[group_id] = {
+                "name": group_name,
+                "dir": group_dir,
+                "fasta": combined_fasta,
+                "query_ids": list(query_hits_map.keys()),
+                "hits": [hit for hits in query_hits_map.values() for hit in hits],
+            }
+
+    tree_files_map = {}
+    if not args.skip_alignment:
+        tree_jobs = []
+        group_job_info = {}
+        for group_id, group_info in group_results.items():
+            result = process_grouped_alignment_and_tree_parallel(
+                group_name=group_info["name"],
+                group_dir=group_info["dir"],
+                taxonomic_rank=args.tree_label_rank,
+                blast_hits=group_info["hits"],
+                query_ids=group_info["query_ids"],
+                num_threads=args.num_threads,
+                background_tree=True,
+            )
+            if result["tree_job"]:
+                tree_jobs.append(result["tree_job"])
+                group_job_info[str(result["tree_file"])] = {
+                    "group_id": group_id,
+                    "group_name": group_info["name"],
+                    "tree_file": result["tree_file"],
+                    "labeled_tree_path": result["labeled_tree_path"],
+                    "blast_hits": result["blast_hits"],
+                    "taxonomic_rank": result["taxonomic_rank"],
+                }
+
+        if tree_jobs:
+            tree_results = IQTreeBuilder.wait_for_tree_jobs(tree_jobs)
+            for tree_path, tree_success in tree_results.items():
+                if not tree_success or tree_path not in group_job_info:
+                    continue
+                job_info = group_job_info[tree_path]
+                for query_id in group_results[job_info["group_id"]]["query_ids"]:
+                    tree_files_map[query_id] = job_info["tree_file"]
+                if args.tree_label_rank == "no_rank":
+                    logger.info("Skipping tree relabeling in no_rank mode for %s", job_info["group_name"])
+                    continue
+                IQTreeBuilder.relabel_tree_with_taxonomy(
+                    tree_file=job_info["tree_file"],
+                    blast_hits=job_info["blast_hits"],
+                    output_tree=job_info["labeled_tree_path"],
+                    taxonomic_rank=job_info["taxonomic_rank"],
+                )
+
+    output_classification = args.output_classification or args.output_dir / f"{args.query_fasta.stem}_classification.tsv"
+    generate_classification_summary(
+        sequences=sequences,
+        blast_hits=filtered_hits,
+        output_file=output_classification,
+        rank=args.rank,
+        group_rank=args.group_rank,
+        tree_label_rank=args.tree_label_rank,
+        tree_files=tree_files_map or None,
+    )
+    logger.info("NBDL-aware grouped workflow completed")
+    return 0
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("query_fasta", type=Path, help="Path to query FASTA file")
+    parser.add_argument("output_dir", type=Path, help="Output directory for results")
+    parser.add_argument("--rank", default="genus", choices=RANK_CHOICES, help="Representative rank, or no_rank for flat databases")
+    parser.add_argument("--tree-label-rank", default="genus", choices=RANK_CHOICES, help="Tree labeling rank, or no_rank")
+    parser.add_argument("--min-identity", type=float, default=90.0, help="Minimum percent identity")
+    parser.add_argument("--min-coverage", type=float, default=80.0, help="Minimum query coverage percentage")
+    parser.add_argument("--database", default="core_nt", help="BLAST database name")
+    parser.add_argument("--blastdb-path", type=Path, default=None, help="Path to BLAST database directory")
+    parser.add_argument("--num-threads", type=int, default=1, help="Threads for BLAST/alignment")
+    parser.add_argument("--overwrite-existing-blast", action="store_true", help="Overwrite existing BLAST results")
+    parser.add_argument("--skip-alignment", action="store_true", help="Skip alignment and tree building")
+    parser.add_argument("--output-classification", type=Path, default=None, help="Path to output classification TSV")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="eplace-nbdl",
+        description="Run ePLACE with NBDL/CSIRO FASTA header taxid parsing",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging verbosity",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    search_parser = subparsers.add_parser("search", help="Run NBDL-aware individual search workflow")
+    _add_common_args(search_parser)
+
+    grouped_parser = subparsers.add_parser("grouped", help="Run NBDL-aware grouped workflow")
+    _add_common_args(grouped_parser)
+    grouped_parser.add_argument("--group-rank", default="class", choices=RANK_CHOICES, help="Grouping rank, or no_rank")
+    grouped_parser.add_argument("--alignment-tolerance", type=int, default=50, help="Maximum coordinate difference for consistency checks")
+
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    if args.command == "search":
+        return search_command(args)
+    if args.command == "grouped":
+        return grouped_command(args)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eplace_lib/taxonomy.py
+++ b/src/eplace_lib/taxonomy.py
@@ -37,7 +37,8 @@ def _subject_id_matches(subject_id: str, target_id: str) -> bool:
 logger = logging.getLogger(__name__)
 
 # Valid taxonomic ranks supported by the library
-VALID_RANKS = ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species']
+# 'no_rank' bypasses taxonomy lookup for custom databases without taxids
+VALID_RANKS = ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species', 'no_rank']
 
 
 def extract_custom_subject_id_and_taxid(
@@ -94,6 +95,11 @@ class TaxonomyExtractor:
         tax_ids = list(set(tax_ids))
         taxonomy_dict = {}
 
+        # Handle empty taxid list (e.g., when using custom databases without taxonomy)
+        if not tax_ids or all(tid == '' for tid in tax_ids):
+            logger.warning("No valid taxonomy IDs provided. Skipping taxonomy lookup.")
+            return taxonomy_dict
+
         # we need to get the whole lineage, and then convert it to a dict
         try:
             df = pytaxonkit.lineage(tax_ids)
@@ -146,9 +152,13 @@ class TaxonomyExtractor:
         """
         Select representative sequences per taxonomic rank.
         
+        When rank='no_rank', bypasses taxonomy lookup and groups by subject_id instead.
+        This mode is useful for custom databases that don't have taxid information.
+        
         Args:
             hits: list of BlastHit objects for a single query
-            rank: Taxonomic rank for representative selection
+            rank: Taxonomic rank for representative selection. Use 'no_rank' to group
+                  by sequence ID instead of taxonomic rank (useful for custom databases).
             max_per_rank: Maximum number of representatives per rank (default: 1)
             preferred_representatives: Optional dictionary mapping rank_tid to preferred subject_id
                                        to ensure consistent representatives across queries
@@ -160,13 +170,21 @@ class TaxonomyExtractor:
         if preferred_representatives is None:
             preferred_representatives = {}
         
-        # Group hits by taxonomic rank (using subject_id as proxy)
+        # Group hits by taxonomic rank (or by subject_id if rank='no_rank')
         rank_groups = defaultdict(list)
         
         reported_hits = set()
         for hit in hits:
+            # Special handling for 'no_rank': group by subject_id instead of taxonomy
+            if rank == 'no_rank':
+                logger.info(
+                    f"Using no_rank mode: grouping by subject_id (custom database mode)"
+                )
+                rank_groups[hit.subject_id].append(hit)
+                continue
+            
             if not hit.subject_taxonomy:
-                # No taxonomy available (e.g. MMseqs2 database without taxonomy).
+                # No taxonomy available (e.g. MMseqs2 database without taxonomy or custom database).
                 # Fall back to grouping by subject_id so the hit still contributes
                 # a representative rather than being silently dropped.
                 logger.info(
@@ -437,10 +455,14 @@ def process_blast_results_for_taxonomy(
     """
     Process BLAST hits to extract representative sequences per taxonomic rank.
     
+    When rank='no_rank', skips taxonomy lookup and groups by sequence ID instead.
+    This mode is useful for custom databases without taxid information.
+    
     Args:
         blast_hits: list of BlastHit objects
         output_dir: Output directory for FASTA files
-        rank: Taxonomic rank for representative selection
+        rank: Taxonomic rank for representative selection. Use 'no_rank' to bypass
+              taxonomy lookup and group by sequence ID (useful for custom databases).
         database: Name of BLAST database
         blastdb_path: Path to BLAST database directory
         custom_header_parser: Optional parser function for custom database headers.
@@ -464,13 +486,20 @@ def process_blast_results_for_taxonomy(
             # This is a fallback if the header wasn't available during BLAST parsing
             logger.debug(f"Custom header parser provided for hit {hit.subject_id}")
     
-    # get all the taxonomies
-    subject_taxids = {hit.subject_taxid for hit in blast_hits}
-    tax_dict = tax_extractor.parse_taxids(list(subject_taxids))
+    # Skip taxonomy lookup entirely if rank is 'no_rank'
+    if rank != 'no_rank':
+        # get all the taxonomies
+        subject_taxids = {hit.subject_taxid for hit in blast_hits}
+        tax_dict = tax_extractor.parse_taxids(list(subject_taxids))
 
-    # add all the ranks to all the hits
-    for h in blast_hits:
-        h.subject_taxonomy = tax_dict.get(h.subject_taxid)
+        # add all the ranks to all the hits
+        for h in blast_hits:
+            h.subject_taxonomy = tax_dict.get(h.subject_taxid)
+    else:
+        # In no_rank mode, we don't use taxonomy information
+        logger.info("Using no_rank mode: skipping taxonomy lookup for custom database")
+        for h in blast_hits:
+            h.subject_taxonomy = None
 
     # Group hits by query
     grouped_hits = tax_extractor.group_hits_by_query(blast_hits)
@@ -497,7 +526,12 @@ def process_blast_results_for_taxonomy(
         
         # Update the preferred representatives with newly selected ones
         for rep in representatives:
-            if (
+            if rank == 'no_rank':
+                # In no_rank mode, use subject_id as the key
+                if rep.subject_id not in preferred_representatives:
+                    preferred_representatives[rep.subject_id] = rep.subject_id
+                    logger.info(f"Recording {rep.subject_id} as representative for no_rank mode")
+            elif (
                 rep.subject_taxonomy
                 and rank in rep.subject_taxonomy
                 and isinstance(rep.subject_taxonomy[rank], tuple)
@@ -561,6 +595,9 @@ def generate_classification_summary(
     - Whether the sequence appears in multiple groups
     - Whether the sequence has no appropriate classification
     
+    When rank='no_rank', taxonomy-based classification is skipped and sequences
+    are identified by their sequence ID instead.
+    
     The classification is based on the phylogenetically nearest neighbor in the tree
     (if available), otherwise falls back to the best BLAST hit by bit score.
     
@@ -568,7 +605,7 @@ def generate_classification_summary(
         sequences: dictionary of sequences that we read from the fasta file
         blast_hits: List of BlastHit objects with taxonomy information
         output_file: Path to output TSV file
-        rank: Taxonomic rank for classification (default: genus)
+        rank: Taxonomic rank for classification (default: genus). Use 'no_rank' to skip taxonomy lookup.
         group_rank: Taxonomic rank for grouping (default: class)
         tree_label_rank: Taxonomic rank for tree labeling (default: genus)
         tree_files: Optional dict mapping query_id to tree file paths for finding nearest neighbors
@@ -641,31 +678,38 @@ def generate_classification_summary(
         # Populate BLAST-based classification
         if blast_best_hit.subject_taxonomy:
             classification['taxonomy_blast'] = ';'.join([blast_best_hit.subject_taxonomy[r][1] if r in blast_best_hit.subject_taxonomy else ""
-                                                   for r in VALID_RANKS])
+                                                   for r in VALID_RANKS if r != 'no_rank'])
+        elif rank == 'no_rank':
+            # In no_rank mode, use subject_id instead of taxonomy
+            classification['taxonomy_blast'] = blast_best_hit.subject_id
+            classification['blast_classification_taxid'] = blast_best_hit.subject_id
+            classification['blast_classification_name'] = blast_best_hit.subject_id
         
         # Extract BLAST-based classification at different ranks
         blast_missing_ranks = []
         
-        if blast_best_hit.subject_taxonomy and rank in blast_best_hit.subject_taxonomy:
-            taxid, name = blast_best_hit.subject_taxonomy[rank]
-            classification['blast_classification_taxid'] = taxid
-            classification['blast_classification_name'] = name
-        else:
-            blast_missing_ranks.append(rank)
-        
-        if blast_best_hit.subject_taxonomy and group_rank in blast_best_hit.subject_taxonomy:
-            taxid, name = blast_best_hit.subject_taxonomy[group_rank]
-            classification['blast_group_taxid'] = taxid
-            classification['blast_group_name'] = name
-        else:
-            blast_missing_ranks.append(group_rank)
-        
-        if blast_best_hit.subject_taxonomy and tree_label_rank in blast_best_hit.subject_taxonomy:
-            taxid, name = blast_best_hit.subject_taxonomy[tree_label_rank]
-            classification['blast_tree_label_taxid'] = taxid
-            classification['blast_tree_label_name'] = name
-        else:
-            blast_missing_ranks.append(tree_label_rank)
+        # Skip taxonomy-based classification when in no_rank mode
+        if rank != 'no_rank':
+            if blast_best_hit.subject_taxonomy and rank in blast_best_hit.subject_taxonomy:
+                taxid, name = blast_best_hit.subject_taxonomy[rank]
+                classification['blast_classification_taxid'] = taxid
+                classification['blast_classification_name'] = name
+            else:
+                blast_missing_ranks.append(rank)
+            
+            if blast_best_hit.subject_taxonomy and group_rank in blast_best_hit.subject_taxonomy:
+                taxid, name = blast_best_hit.subject_taxonomy[group_rank]
+                classification['blast_group_taxid'] = taxid
+                classification['blast_group_name'] = name
+            else:
+                blast_missing_ranks.append(group_rank)
+            
+            if blast_best_hit.subject_taxonomy and tree_label_rank in blast_best_hit.subject_taxonomy:
+                taxid, name = blast_best_hit.subject_taxonomy[tree_label_rank]
+                classification['blast_tree_label_taxid'] = taxid
+                classification['blast_tree_label_name'] = name
+            else:
+                blast_missing_ranks.append(tree_label_rank)
         
         # Try to get tree-based classification
         tree_best_hit = None
@@ -698,52 +742,58 @@ def generate_classification_summary(
         if tree_best_hit:
             if tree_best_hit.subject_taxonomy:
                 classification['taxonomy_tree'] = ';'.join([tree_best_hit.subject_taxonomy[r][1] if r in tree_best_hit.subject_taxonomy else ""
-                                                       for r in VALID_RANKS])
+                                                       for r in VALID_RANKS if r != 'no_rank'])
+            elif rank == 'no_rank':
+                classification['taxonomy_tree'] = tree_best_hit.subject_id
+                classification['tree_classification_taxid'] = tree_best_hit.subject_id
+                classification['tree_classification_name'] = tree_best_hit.subject_id
             
             tree_missing_ranks = []
             
-            if tree_best_hit.subject_taxonomy and rank in tree_best_hit.subject_taxonomy:
-                taxid, name = tree_best_hit.subject_taxonomy[rank]
-                classification['tree_classification_taxid'] = taxid
-                classification['tree_classification_name'] = name
-            else:
-                tree_missing_ranks.append(rank)
-            
-            if tree_best_hit.subject_taxonomy and group_rank in tree_best_hit.subject_taxonomy:
-                taxid, name = tree_best_hit.subject_taxonomy[group_rank]
-                classification['tree_group_taxid'] = taxid
-                classification['tree_group_name'] = name
-            else:
-                tree_missing_ranks.append(group_rank)
-            
-            if tree_best_hit.subject_taxonomy and tree_label_rank in tree_best_hit.subject_taxonomy:
-                taxid, name = tree_best_hit.subject_taxonomy[tree_label_rank]
-                classification['tree_tree_label_taxid'] = taxid
-                classification['tree_tree_label_name'] = name
-            else:
-                tree_missing_ranks.append(tree_label_rank)
+            if rank != 'no_rank':
+                if tree_best_hit.subject_taxonomy and rank in tree_best_hit.subject_taxonomy:
+                    taxid, name = tree_best_hit.subject_taxonomy[rank]
+                    classification['tree_classification_taxid'] = taxid
+                    classification['tree_classification_name'] = name
+                else:
+                    tree_missing_ranks.append(rank)
+                
+                if tree_best_hit.subject_taxonomy and group_rank in tree_best_hit.subject_taxonomy:
+                    taxid, name = tree_best_hit.subject_taxonomy[group_rank]
+                    classification['tree_group_taxid'] = taxid
+                    classification['tree_group_name'] = name
+                else:
+                    tree_missing_ranks.append(group_rank)
+                
+                if tree_best_hit.subject_taxonomy and tree_label_rank in tree_best_hit.subject_taxonomy:
+                    taxid, name = tree_best_hit.subject_taxonomy[tree_label_rank]
+                    classification['tree_tree_label_taxid'] = taxid
+                    classification['tree_tree_label_name'] = name
+                else:
+                    tree_missing_ranks.append(tree_label_rank)
         
         # Set classification status based on BLAST missing ranks
-        if blast_missing_ranks:
+        if rank != 'no_rank' and blast_missing_ranks:
             if len(blast_missing_ranks) == 3:  # All three ranks missing
                 classification['has_classification'] = 'No'
             else:
                 classification['has_classification'] = 'Partial'
         
         # Check if sequence appears in multiple groups at the group_rank level
-        group_names = set()
-        group_taxids = set()
-        for hit in query_hits:
-            if hit.subject_taxonomy and group_rank in hit.subject_taxonomy:
-                taxid, name = hit.subject_taxonomy[group_rank]
-                group_names.add(name)
-                group_taxids.add(str(taxid))
+        if rank != 'no_rank':
+            group_names = set()
+            group_taxids = set()
+            for hit in query_hits:
+                if hit.subject_taxonomy and group_rank in hit.subject_taxonomy:
+                    taxid, name = hit.subject_taxonomy[group_rank]
+                    group_names.add(name)
+                    group_taxids.add(str(taxid))
 
-        if len(group_names) > 1:
-            classification['appears_in_multiple_groups'] = 'Yes'
-            # Update BLAST group names/taxids to show all groups
-            classification['blast_group_name'] = '; '.join(sorted(group_names))
-            classification['blast_group_taxid'] = '; '.join(sorted(group_taxids))
+            if len(group_names) > 1:
+                classification['appears_in_multiple_groups'] = 'Yes'
+                # Update BLAST group names/taxids to show all groups
+                classification['blast_group_name'] = '; '.join(sorted(group_names))
+                classification['blast_group_taxid'] = '; '.join(sorted(group_taxids))
         
         summary_data.append(classification)
     

--- a/src/eplace_lib/taxonomy.py
+++ b/src/eplace_lib/taxonomy.py
@@ -11,10 +11,10 @@ import subprocess
 import logging
 import sys
 from pathlib import Path
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple, Callable
 from collections import defaultdict
 
-from .blast_analysis import BlastHit, normalize_sequence_id
+from .blast_analysis import BlastHit, normalize_sequence_id, _parse_nbdl_custom_header
 
 import pytaxonkit
 
@@ -38,6 +38,41 @@ logger = logging.getLogger(__name__)
 
 # Valid taxonomic ranks supported by the library
 VALID_RANKS = ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species']
+
+
+def extract_custom_subject_id_and_taxid(
+    subject_id: str,
+    header: Optional[str] = None,
+    custom_header_parser: Optional[Callable[[str], Tuple[str, str, str]]] = None
+) -> Tuple[str, str]:
+    """
+    Extract the subject_id and taxid from a BLAST subject ID, optionally parsing
+    a custom header format.
+    
+    This function handles both standard NCBI-formatted IDs and custom database headers
+    (e.g., NBDL format). If a custom_header_parser is provided and a header is given,
+    it uses the parser to extract the sequence ID and taxid. Otherwise, it returns
+    the original subject_id and an empty taxid.
+    
+    Args:
+        subject_id: The original BLAST subject ID (typically from BLAST output).
+        header: The full FASTA header (optional), used with custom_header_parser.
+        custom_header_parser: Optional parser function that takes a header string and
+                             returns a tuple of (seq_id, description, taxid).
+    
+    Returns:
+        Tuple of (canonical_subject_id, taxid).
+        If no custom parser or header is provided, returns (subject_id, '').
+    """
+    if custom_header_parser and header:
+        try:
+            seq_id, description, taxid = custom_header_parser(header)
+            return (seq_id, taxid)
+        except Exception as e:
+            logger.warning(f"Error parsing custom header: {e}. Using original subject_id.")
+            return (subject_id, '')
+    
+    return (subject_id, '')
 
 
 class TaxonomyExtractor:
@@ -116,7 +151,7 @@ class TaxonomyExtractor:
             rank: Taxonomic rank for representative selection
             max_per_rank: Maximum number of representatives per rank (default: 1)
             preferred_representatives: Optional dictionary mapping rank_tid to preferred subject_id
-                                      to ensure consistent representatives across queries
+                                       to ensure consistent representatives across queries
             
         Returns:
             list of representative BlastHit objects
@@ -396,7 +431,8 @@ def process_blast_results_for_taxonomy(
     output_dir: Path,
     rank: str = "genus",
     database: str = "core_nt",
-    blastdb_path: Optional[Path] = None
+    blastdb_path: Optional[Path] = None,
+    custom_header_parser: Optional[Callable[[str], Tuple[str, str, str]]] = None
 ) -> Dict[str, Optional[Path]]:
     """
     Process BLAST hits to extract representative sequences per taxonomic rank.
@@ -407,6 +443,8 @@ def process_blast_results_for_taxonomy(
         rank: Taxonomic rank for representative selection
         database: Name of BLAST database
         blastdb_path: Path to BLAST database directory
+        custom_header_parser: Optional parser function for custom database headers.
+                             Should take a header string and return (seq_id, description, taxid).
         
     Returns:
         dictionary mapping query IDs to output FASTA file paths
@@ -417,6 +455,14 @@ def process_blast_results_for_taxonomy(
 
     tax_extractor = TaxonomyExtractor()
     seq_extractor = SequenceExtractor(blastdb_path)
+    
+    # If custom header parser is provided, extract taxids from headers and override subject_taxid
+    if custom_header_parser:
+        for hit in blast_hits:
+            # Try to extract taxid from the subject_id using custom parser
+            # (subject_id in BLAST output may already be parsed by custom parser)
+            # This is a fallback if the header wasn't available during BLAST parsing
+            logger.debug(f"Custom header parser provided for hit {hit.subject_id}")
     
     # get all the taxonomies
     subject_taxids = {hit.subject_taxid for hit in blast_hits}


### PR DESCRIPTION
This update is to accommodate reference databases which may not support NCBI style headers. By adjusting the script to auto detect header type, different reference style databases can be used and will not break the rank argument in eplace. 